### PR TITLE
Fix some deprecation and uninitialized variable warning and fix issue cause by self:=nil 

### DIFF
--- a/lib/levents.pp
+++ b/lib/levents.pp
@@ -15,7 +15,7 @@
   You should have received a Copy of the GNU Library General Public License
   along with This library; if not, Write to the Free Software Foundation,
   Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-  
+
   This license has been modified. See File LICENSE.ADDON for more inFormation.
   Should you find these sources without a LICENSE File, please contact
   me at ales@chello.sk
@@ -47,7 +47,7 @@ type
   TLHandleEvent = procedure (aHandle: TLHandle) of object;
   TLHandleErrorEvent = procedure (aHandle: TLHandle; const msg: string) of object;
   TLEventerErrorEvent = procedure (const msg: string; Sender: TLEventer) of object;
-  
+
   { TLHandle }
 
   TLHandle = class(TObject)
@@ -67,7 +67,7 @@ type
     FNext: TLHandle;
     FFreeNext: TLHandle;
     FInternalData: Pointer;
-    
+
     procedure SetIgnoreError(const aValue: Boolean);
     procedure SetIgnoreWrite(const aValue: Boolean);
     procedure SetIgnoreRead(const aValue: Boolean);
@@ -172,7 +172,7 @@ type
     property Count: Integer read GetCount;
   end;
   TLEventerClass = class of TLEventer;
-  
+
   { TLSelectEventer }
 
   TLSelectEventer = class(TLEventer)
@@ -188,21 +188,21 @@ type
     constructor Create; override;
     function CallAction: Boolean; override;
   end;
-  
+
 {$i sys/lkqueueeventerh.inc}
 {$i sys/lepolleventerh.inc}
 
   function BestEventerClass: TLEventerClass;
-  
+
 implementation
 
 uses
   syncobjs,
   lCommon;
-  
+
 var
   CS: TCriticalSection;
-  
+
 { TLHandle }
 
 procedure TLHandle.SetIgnoreError(const aValue: Boolean);
@@ -287,7 +287,7 @@ end;
 
 procedure TLTimer.CallAction;
 begin
-  if FEnabled and Assigned(FOnTimer) and (Now - FStarted >= FInterval) then 
+  if FEnabled and Assigned(FOnTimer) and (Now - FStarted >= FInterval) then
   begin
     FOnTimer(Self);
     if not FOneShot then
@@ -537,6 +537,7 @@ var
   MaxHandle: THandle;
   TempTime: TTimeVal;
 begin
+  result := false;
   if FInLoop then
     Exit;
 
@@ -575,11 +576,11 @@ begin
     n := fpSelect(MaxHandle + 1, @FReadFDSet, @FWriteFDSet, @FErrorFDSet, @TempTime)
   else
     n := fpSelect(MaxHandle + 1, @FReadFDSet, @FWriteFDSet, @FErrorFDSet, nil);
-  
+
   if n < 0 then
     Bail('Error on select', LSocketError);
   Result := n > 0;
-  
+
   if Result then begin
     Temp := FRoot;
     while Assigned(Temp) do begin

--- a/lib/lfastcgi.pp
+++ b/lib/lfastcgi.pp
@@ -603,6 +603,8 @@ var
   end;
 
 begin
+  lCode := 0;
+  lIntVal := 0;
   repeat
     lBufferPtr := FBufferPos;
     Inc(lBufferPtr, GetFastCGIStringSize(PByte(lBufferPtr), lNameLen));

--- a/lib/lnet.pp
+++ b/lib/lnet.pp
@@ -15,7 +15,7 @@
   You should have received a Copy of the GNU Library General Public License
   along with This library; if not, Write to the Free Software Foundation,
   Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-  
+
   This license has been modified. See File LICENSE.ADDON for more inFormation.
   Should you find these sources without a LICENSE File, please contact
   me at ales@chello.sk
@@ -97,12 +97,12 @@ type
     function GetIPAddressLength: TSocklen;
 
     function SetupSocket(const APort: Word; const Address: string): Boolean; virtual;
-    
+
     function DoSend(const aData; const aSize: Integer): Integer; virtual;
     function DoGet(out aData; const aSize: Integer): Integer; virtual;
 
     function HandleResult(const aResult: Integer; aOp: TLSocketOperation): Integer; virtual;
-    
+
     function GetLocalPort: Word;
     function GetPeerPort: Word;
     function GetPeerAddress: string;
@@ -119,26 +119,26 @@ type
     procedure SoftDisconnect;
 
     function Bail(const msg: string; const ernum: Integer): Boolean;
-    
+
     function LogError(const msg: string; const ernum: Integer): Boolean; virtual;
-    
+
     property SocketType: Integer read FSocketType write FSocketType; // inherit and publicize if you need to set this outside
    public
     constructor Create; override;
     destructor Destroy; override;
-    
+
     function SetState(const aState: TLSocketState; const TurnOn: Boolean = True): Boolean; virtual;
-    
+
     function Listen(const APort: Word; const AIntf: string = LADDR_ANY): Boolean;
     function Accept(const SerSock: TSocket): Boolean;
     function Connect(const Address: string; const APort: Word): Boolean;
-    
+
     function Send(const aData; const aSize: Integer): Integer; virtual;
     function SendMessage(const msg: string): Integer;
-    
+
     function Get(out aData; const aSize: Integer): Integer; virtual;
     function GetMessage(out msg: string): Integer;
-    
+
     procedure Disconnect(const Forced: Boolean = False); virtual;
    public
     property Connected: Boolean read GetConnected; deprecated;
@@ -158,22 +158,22 @@ type
     property Session: TLSession read FSession;
   end;
   TLSocketClass = class of TLSocket;
-  
+
   { this is the socket used by TLConnection }
-  
+
   TLActionEnum = (acConnect, acAccept, acSend, acReceive, acError);
 
   { Base interface common to ALL connections }
-  
+
   ILComponent = interface
     procedure Disconnect(const Forced: Boolean = False);
     procedure CallAction;
-    
+
     property SocketClass: TLSocketClass;
     property Host: string;
     property Port: Word;
   end;
-  
+
   { Interface for protools with direct send/get capabilities }
 
   ILDirect = interface
@@ -183,20 +183,20 @@ type
     function Send(const aData; const aSize: Integer; aSocket: TLSocket = nil): Integer;
     function SendMessage(const msg: string; aSocket: TLSocket = nil): Integer;
   end;
-  
+
   { Interface for all servers }
-  
+
   ILServer = interface
     function Listen(const APort: Word; const AIntf: string = LADDR_ANY): Boolean;
   end;
 
   { Interface for all clients }
-  
+
   ILClient = interface
     function Connect(const Address: string; const APort: Word): Boolean; overload;
     function Connect: Boolean; overload;
   end;
-  
+
   { TLComponent }
 
   TLComponent = class(TComponent, ILComponent)
@@ -217,7 +217,7 @@ type
     property Creator: TLComponent read FCreator write SetCreator;
     property Active: Boolean read FActive;
   end;
-  
+
   { TLConnection
     Common ancestor for TLTcp and TLUdp classes. Holds Event properties
     and common variables. }
@@ -243,14 +243,14 @@ type
     FSocketNet: Integer;
    protected
     function InitSocket(aSocket: TLSocket): TLSocket; virtual;
-    
+
     function GetConnected: Boolean; virtual; abstract;
     function GetCount: Integer; virtual;
     function GetItem(const i: Integer): TLSocket;
-    
+
     function GetTimeout: Integer;
     procedure SetTimeout(const AValue: Integer);
-    
+
     procedure SetReuseAddress(const aValue: Boolean);
     procedure SetEventer(Value: TLEventer);
     procedure SetSession(aSession: TLSession);
@@ -262,7 +262,7 @@ type
     procedure ReceiveAction(aSocket: TLHandle); virtual;
     procedure SendAction(aSocket: TLHandle); virtual;
     procedure ErrorAction(aSocket: TLHandle; const msg: string); virtual;
-    
+
     procedure ConnectEvent(aSocket: TLHandle); virtual;
     procedure DisconnectEvent(aSocket: TLHandle); virtual;
     procedure AcceptEvent(aSocket: TLHandle); virtual;
@@ -270,26 +270,26 @@ type
     procedure CanSendEvent(aSocket: TLHandle); virtual;
     procedure ErrorEvent(aSocket: TLHandle; const msg: string); virtual;
     procedure EventerError(const msg: string; Sender: TLEventer);
-    
+
     procedure RegisterWithEventer; virtual;
-    
+
     procedure FreeSocks(const Forced: Boolean); virtual;
    public
     constructor Create(aOwner: TComponent); override;
     destructor Destroy; override;
-    
+
     function Connect(const Address: string; const APort: Word): Boolean; virtual; overload;
     function Connect: Boolean; virtual; overload;
-    
+
     function Listen(const APort: Word; const AIntf: string = LADDR_ANY): Boolean; virtual; abstract; overload;
     function Listen: Boolean; virtual; overload;
-    
+
     function Get(out aData; const aSize: Integer; aSocket: TLSocket = nil): Integer; virtual; abstract;
     function GetMessage(out msg: string; aSocket: TLSocket = nil): Integer; virtual; abstract;
-    
+
     function Send(const aData; const aSize: Integer; aSocket: TLSocket = nil): Integer; virtual; abstract;
     function SendMessage(const msg: string; aSocket: TLSocket = nil): Integer; virtual; abstract;
-    
+
     function IterNext: Boolean; virtual; abstract;
     procedure IterReset; virtual; abstract;
    public
@@ -309,36 +309,36 @@ type
     property ReuseAddress: Boolean read FReuseAddress write SetReuseAddress;
     property SocketNet: Integer read FSocketNet write SetSocketNet;
   end;
-  
+
   { TLUdp }
 
   TLUdp = class(TLConnection)
    protected
     function InitSocket(aSocket: TLSocket): TLSocket; override;
-    
+
     function GetConnected: Boolean; override;
-    
+
     procedure ReceiveAction(aSocket: TLHandle); override;
     procedure ErrorAction(aSocket: TLHandle; const msg: string); override;
-    
+
     function Bail(const msg: string): Boolean;
-    
+
     procedure SetAddress(const Address: string);
    public
     constructor Create(aOwner: TComponent); override;
-    
+
     function Connect(const Address: string; const APort: Word): Boolean; override;
     function Listen(const APort: Word; const AIntf: string = LADDR_ANY): Boolean; override;
-    
+
     function Get(out aData; const aSize: Integer; aSocket: TLSocket = nil): Integer; override;
     function GetMessage(out msg: string; aSocket: TLSocket = nil): Integer; override;
-    
+
     function SendMessage(const msg: string; aSocket: TLSocket = nil): Integer; override;
     function SendMessage(const msg: string; const Address: string): Integer; overload;
-    
+
     function Send(const aData; const aSize: Integer; aSocket: TLSocket = nil): Integer; override;
     function Send(const aData; const aSize: Integer; const Address: string): Integer; overload;
-    
+
     function IterNext: Boolean; override;
     procedure IterReset; override;
 
@@ -346,7 +346,7 @@ type
 
     procedure CallAction; override;
   end;
-  
+
   { TLTcp }
 
   TLTcp = class(TLConnection)
@@ -455,7 +455,7 @@ begin
                             FSocketState := FSocketState + [aState]
                           else
                             raise Exception.Create('Can not turn off server socket feature');
-                            
+
     ssBlocking          : SetBlocking(TurnOn);
     ssReuseAddress      : SetReuseAddress(TurnOn);
 
@@ -464,11 +464,11 @@ begin
                             FSocketState := FSocketState + [aState]
                           else
                             FSocketState := FSocketState - [aState];
-    
+
     ssSSLActive         : raise Exception.Create('Can not turn SSL/TLS on in TLSocket instance');
     ssNoDelay           : SetNoDelay(TurnOn);
   end;
-  
+
   Result := True;
 end;
 
@@ -642,7 +642,7 @@ end;
 function TLSocket.Get(out aData; const aSize: Integer): Integer;
 begin
   Result := 0;
-  
+
   if aSize = 0 then
     raise Exception.Create('Invalid buffer size 0 in Get');
 
@@ -656,7 +656,7 @@ begin
         Bail('Receive Error [0 on recvfrom with UDP]', 0);
         Exit(0);
       end;
-      
+
     Result := HandleResult(Result, soReceive);
   end;
 end;
@@ -725,13 +725,13 @@ begin
       if fpsetsockopt(FHandle, SOL_SOCKET, Opt, @Arg, Sizeof(Arg)) = SOCKET_ERROR then
         Exit(Bail('SetSockOpt error', LSocketError));
     end;
-    
+
     {$ifdef darwin}
     Arg := 1;
     if fpsetsockopt(FHandle, SOL_SOCKET, SO_NOSIGPIPE, @Arg, Sizeof(Arg)) = SOCKET_ERROR then
       Exit(Bail('SetSockOpt error', LSocketError));
     {$endif}
-    
+
     FillAddressInfo(FAddress, FSocketNet, Address, aPort);
     FillAddressInfo(FPeerAddress, FSocketNet, LADDR_BR, aPort);
 
@@ -743,6 +743,7 @@ function TLSocket.DoSend(const aData; const aSize: Integer): Integer;
 var
   AddressLength: Longint = SizeOf(FPeerAddress);
 begin
+  result := 0;
   if FSocketType = SOCK_STREAM then
     Result := Sockets.fpSend(FHandle, @aData, aSize, LMSG)
   else begin
@@ -765,6 +766,7 @@ function TLSocket.DoGet(out aData; const aSize: Integer): Integer;
 var
   AddressLength: Longint = SizeOf(FPeerAddress);
 begin
+  result := 0;
   if FSocketType = SOCK_STREAM then
     Result := sockets.fpRecv(FHandle, @aData, aSize, LMSG)
   else begin
@@ -810,7 +812,7 @@ begin
       HardDisconnect(True); {$warning check if we need aOp = soSend in the IF, perhaps bad recv is possible?}
     end else
       Bail(GSStr[aOp] + ' error', LastError);
-      
+
     Result := 0;
   end;
 end;
@@ -869,10 +871,10 @@ end;
 function TLSocket.Connect(const Address: string; const aPort: Word): Boolean;
 begin
   Result := False;
-  
+
   if FConnectionStatus <> scNone then
     Disconnect(True);
-    
+
   if SetupSocket(APort, Address) then begin
     fpConnect(FHandle, GetIPAddressPointer, GetIPAddressLength);
     FConnectionStatus := scConnecting;
@@ -888,7 +890,7 @@ end;
 function TLSocket.Send(const aData; const aSize: Integer): Integer;
 begin
   Result := 0;
-  
+
   if aSize = 0 then
     raise Exception.Create('Invalid buffersize 0 in Send');
 
@@ -991,7 +993,7 @@ procedure TLConnection.Notification(AComponent: TComponent;
   Operation: TOperation);
 begin
   inherited Notification(AComponent, Operation);
-  
+
   if (Operation = opRemove) and (AComponent = FSession) then
     FSession := nil;
 end;
@@ -1193,7 +1195,7 @@ begin
   FIterator := FRootSock;
 
   Result := FRootSock.SetupSocket(APort, LADDR_ANY);
-  
+
   if Result then begin
     FillAddressInfo(FRootSock.FPeerAddress, FRootSock.FSocketNet, Address, aPort);
     FRootSock.FConnectionStatus := scConnected;
@@ -1214,7 +1216,7 @@ begin
 
   if FRootSock.Listen(APort, AIntf) then begin
     FillAddressInfo(FRootSock.FPeerAddress, FRootSock.FSocketNet, LADDR_BR, aPort);
-  
+
     FRootSock.FConnectionStatus := scConnected;
     RegisterWithEventer;
     Result := True;
@@ -1371,13 +1373,13 @@ end;
 function TLTcp.Connect(const Address: string; const APort: Word): Boolean;
 begin
   Result := inherited Connect(Address, aPort);
-  
+
   if Assigned(FRootSock) then
     Disconnect(True);
-    
+
   FRootSock := InitSocket(SocketClass.Create);
   Result := FRootSock.Connect(Address, aPort);
-  
+
   if Result then begin
     Inc(FCount);
     FIterator := FRootSock;
@@ -1391,10 +1393,10 @@ end;
 function TLTcp.Listen(const APort: Word; const AIntf: string = LADDR_ANY): Boolean;
 begin
   Result := false;
-  
+
   if Assigned(FRootSock) then
     Disconnect(True);
-  
+
   FRootSock := InitSocket(SocketClass.Create);
   FRootSock.SetReuseAddress(FReuseAddress);
   if FRootSock.Listen(APort, AIntf) then begin
@@ -1440,7 +1442,7 @@ begin
     aSocket.PrevSock.NextSock := aSocket.NextSock;
   if Assigned(aSocket.NextSock) then
     aSocket.NextSock.PrevSock := aSocket.PrevSock;
-    
+
   Dec(FCount);
 end;
 
@@ -1524,23 +1526,23 @@ var
   Tmp: TLSocket;
 begin
   Tmp := InitSocket(SocketClass.Create);
-  
+
   if Tmp.Accept(FRootSock.FHandle) then begin
     if Assigned(FRootSock.FNextSock) then begin
       Tmp.FNextSock := FRootSock.FNextSock;
       FRootSock.FNextSock.FPrevSock := Tmp;
     end;
-    
+
     FRootSock.FNextSock := Tmp;
     Tmp.FPrevSock := FRootSock;
-    
+
     if not Assigned(FIterator)      // if we don't have (bug?) an iterator yet
     or (ssServerSocket in FIterator.SocketState) then // or if it's the first socket accepted
       FIterator := Tmp;  // assign it as iterator (don't assign later acceptees)
-      
+
     Inc(FCount);
     FEventer.AddHandle(Tmp);
-    
+
     Tmp.FConnectionStatus := scConnected;
     Tmp.IgnoreWrite := True;
 
@@ -1588,7 +1590,7 @@ begin
     Self.Bail('Error on connect: connection refused', TLSocket(aSocket));
     Exit;
   end;
-  
+
   if Assigned(FSession) then
     FSession.ErrorEvent(aSocket, msg)
   else
@@ -1626,7 +1628,7 @@ end;
 function TLTcp.GetValidSocket: TLSocket;
 begin
   Result := nil;
-  
+
   if Assigned(FIterator) and not (ssServerSocket in FIterator.SocketState) then
     Result := FIterator
   else if Assigned(FRootSock) and Assigned(FRootSock.FNextSock) then

--- a/lib/lwebserver.pp
+++ b/lib/lwebserver.pp
@@ -654,13 +654,6 @@ var
   tempStr: string;
 begin
   lServerSocket := TLHTTPServerSocket(FSocket);
-{
-  FProcess.Environment.Add('SERVER_ADDR=');
-  FProcess.Environment.Add('SERVER_ADMIN=');
-  FProcess.Environment.Add('SERVER_NAME=');
-  FProcess.Environment.Add('SERVER_PORT=');
-}
-  Self := nil;
   tempStr := TLHTTPServer(lServerSocket.Creator).ServerSoftware;
   if Length(tempStr) > 0 then
     AddEnvironment('SERVER_SOFTWARE', tempStr);

--- a/lib/lwebserver.pp
+++ b/lib/lwebserver.pp
@@ -15,7 +15,7 @@
   You should have received a Copy of the GNU Library General Public License
   along with This library; if not, Write to the Free Software Foundation,
   Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-  
+
   This license has been modified. See file LICENSE.ADDON for more information.
   Should you find these sources without a LICENSE File, please contact
   me at ales@chello.sk
@@ -70,7 +70,7 @@ type
     FParsePos: pchar;
     FReadPos: integer;
     FParsingHeaders: boolean;
-   
+
     procedure AddEnvironment(const AName, AValue: string); virtual; abstract;
     procedure AddHTTPParam(const AName: string; AParam: TLHTTPParameter);
     function  ParseHeaders: boolean;
@@ -184,7 +184,7 @@ type
 
     constructor Create;
     destructor Destroy; override;
-    
+
     procedure RegisterHandler(AHandler: TDocumentHandler);
 
     property DirIndexList: TStrings read FDirIndexList;
@@ -260,9 +260,9 @@ type
     destructor Destroy; override;
 
     function AddVariables(Variables: pchar; ASize: integer; SepChar: char): integer;
-    procedure DeleteCookie(const AName: string; const APath: string = '/'; 
+    procedure DeleteCookie(const AName: string; const APath: string = '/';
         const ADomain: string = '');
-    procedure SetCookie(const AName, AValue: string; const AExpires: TDateTime; 
+    procedure SetCookie(const AName, AValue: string; const AExpires: TDateTime;
         const APath: string = '/'; const ADomain: string = '');
 
     property OnExtraHeaders: TNotifyEvent read FOnExtraHeaders write FOnExtraHeaders;
@@ -294,7 +294,7 @@ uses
 const
   InputBufferEmptyToWriteStatus: array[boolean] of TWriteBlockStatus =
     (wsPendingData, wsWaitingData);
-  
+
 procedure InternalWrite(const s: string);
 begin
   if EnableWriteln then
@@ -322,9 +322,13 @@ begin
     lExecPath := FCGIRoot+lExecPath;
     if SeparatePath(lExecPath, lOutput.FExtraPath, faAnyFile and not faDirectory) then
     begin
+      {$IF FPC_FULLVERSION < 32000}
       lOutput.Process.CommandLine := lExecPath;
+      {$ELSE}
+      lOutput.Process.Executable := lExecPath;
+      {$ENDIF}
       lOutput.FScriptFileName := lExecPath;
-      lOutput.FScriptName := Copy(lExecPath, Length(FCGIRoot), 
+      lOutput.FScriptName := Copy(lExecPath, Length(FCGIRoot),
         Length(lExecPath)-Length(FCGIRoot)+1);
       lOutput.StartRequest;
     end else
@@ -416,7 +420,7 @@ begin
   DoDirSeparators(LDocRequest.Document);
   lDocRequest.Document := IncludeTrailingPathDelimiter(DocumentRoot)
     + lDocRequest.Document;
-  lDocRequest.InfoValid := SeparatePath(lDocRequest.Document,lDocRequest.ExtraPath, 
+  lDocRequest.InfoValid := SeparatePath(lDocRequest.Document,lDocRequest.ExtraPath,
     faAnyFile, @lDocRequest.Info);
   if not lDocRequest.InfoValid then
     exit;
@@ -431,7 +435,7 @@ begin
       for I := 0 to FDirIndexList.Count - 1 do
       begin
         lTempDoc := lDocRequest.Document + FDirIndexList.Strings[I];
-        lDocRequest.InfoValid := FindFirst(lTempDoc, 
+        lDocRequest.InfoValid := FindFirst(lTempDoc,
           faAnyFile and not faDirectory, lDocRequest.Info) = 0;
         FindClose(lDocRequest.Info);
         if lDocRequest.InfoValid and ((lDocRequest.Info.Attr and faDirectory) = 0) then
@@ -583,7 +587,7 @@ end;
 destructor TFileOutput.Destroy;
 begin
   inherited;
-  
+
   if not FEof then
     Close(FFile);
 end;
@@ -608,7 +612,7 @@ function TFileOutput.FillBuffer: TWriteBlockStatus;
 var
   lRead: integer;
 begin
-  if FEof then 
+  if FEof then
     exit(wsDone);
   BlockRead(FFile, FBuffer[FBufferPos], FBufferSize-FBufferPos, lRead);
   Inc(FBufferPos, lRead);
@@ -657,7 +661,7 @@ begin
   if Length(tempStr) > 0 then
     AddEnvironment('SERVER_SOFTWARE', tempStr);
 
-  AddEnvironment('GATEWAY_INTERFACE', 'CGI/1.1'); 
+  AddEnvironment('GATEWAY_INTERFACE', 'CGI/1.1');
   AddEnvironment('SERVER_PROTOCOL', lServerSocket.FRequestInfo.VersionStr);
   AddEnvironment('REQUEST_METHOD', lServerSocket.FRequestInfo.Method);
   AddEnvironment('REQUEST_URI', '/'+lServerSocket.FRequestInfo.Argument);
@@ -671,7 +675,7 @@ begin
 
   AddEnvironment('SCRIPT_NAME', FScriptName);
   AddEnvironment('SCRIPT_FILENAME', FScriptFileName);
-  
+
   AddEnvironment('QUERY_STRING', lServerSocket.FRequestInfo.QueryParams);
   AddHTTPParam('CONTENT_TYPE', hpContentType);
   AddHTTPParam('CONTENT_LENGTH', hpContentLength);
@@ -682,7 +686,7 @@ begin
   { used when user has authenticated in some way to server }
 //  AddEnvironment('AUTH_TYPE='+...);
 //  AddEnvironment('REMOTE_USER='+...);
-  
+
   AddEnvironment('DOCUMENT_ROOT', FDocumentRoot);
   AddEnvironment('REDIRECT_STATUS', '200');
   AddHTTPParam('HTTP_HOST', hpHost);
@@ -708,7 +712,7 @@ var
 
   procedure AddExtraHeader;
   begin
-    AppendString(lServerSocket.FHeaderOut.ExtraHeaders, 
+    AppendString(lServerSocket.FHeaderOut.ExtraHeaders,
       FParsePos + ': ' + pValue + #13#10);
   end;
 
@@ -740,7 +744,7 @@ begin
     if StrIComp(FParsePos, 'Content-type') = 0 then
     begin
       lServerSocket.FResponseInfo.ContentType := pValue;
-    end else 
+    end else
     if StrIComp(FParsePos, 'Location') = 0 then
     begin
       if StrLIComp(pValue, 'http://', 7) = 0 then
@@ -750,7 +754,7 @@ begin
         AddExtraHeader;
       end else
         InternalWrite('WARNING: unimplemented ''Location'' response received from CGI script');
-    end else 
+    end else
     if StrIComp(FParsePos, 'Status') = 0 then
     begin
       { sometimes we get '<status code> space <reason>' }
@@ -773,7 +777,7 @@ begin
     end else
     if StrIComp(FParsePos, 'Last-Modified') = 0 then
     begin
-      if not TryHTTPDateStrToDateTime(pValue, 
+      if not TryHTTPDateStrToDateTime(pValue,
           lServerSocket.FResponseInfo.LastModified) then
         InternalWrite('WARNING: unable to parse last-modified string from CGI script: ' + pValue);
     end else
@@ -870,7 +874,7 @@ end;
 procedure TSimpleCGIOutput.StartRequest;
 begin
   inherited;
-  
+
   FProcess.Eventer := FSocket.Eventer;
   FProcess.Execute;
 end;
@@ -1009,7 +1013,7 @@ begin
   FRequest.DoneParams;
 end;
 
-{ TFormOutput } 
+{ TFormOutput }
 
 constructor TFormOutput.Create(ASocket: TLHTTPSocket);
 begin
@@ -1065,7 +1069,7 @@ begin
       i := FRequestVars.Add(strName);
       tmpObj := nil;
       string(tmpObj) := strValue;
-      FRequestVars.Objects[i] := tmpObj; 
+      FRequestVars.Objects[i] := tmpObj;
     end;
     varname := next+1;
   until false;
@@ -1184,7 +1188,7 @@ begin
     FOnFillBuffer(Self, Result);
 end;
 
-procedure TFormOutput.DeleteCookie(const AName: string; const APath: string = '/'; 
+procedure TFormOutput.DeleteCookie(const AName: string; const APath: string = '/';
   const ADomain: string = '');
 begin
   { cookies expire when expires is in the past, duh }

--- a/lib/lwebserver.pp
+++ b/lib/lwebserver.pp
@@ -479,7 +479,11 @@ begin
   begin
     lOutput := TSimpleCGIOutput.Create(ARequest.Socket);
     lOutput.FDocumentRoot := FFileHandler.DocumentRoot;
+    {$IF FPC_FULLVERSION < 32000}
     lOutput.Process.CommandLine := FAppName;
+    {$ELSE}
+    lOutput.Process.Executable := FAppName;
+    {$ENDIF}
     lOutput.FScriptName := ARequest.URIPath;
     lOutput.FScriptFileName := ARequest.Document;
     lOutput.FExtraPath := ARequest.ExtraPath;


### PR DESCRIPTION
Fix some deprecation warning (TProcess.CommandLine) and uninitialized variable warning.

fix issue cause by setting self to nil cause subsequent method call to fail in lwebserver.pp line 655 