### PR TITLE
Add support for QT5 and QT6

### DIFF
--- a/lazaruspackage/lclnet.pas
+++ b/lazaruspackage/lclnet.pas
@@ -76,8 +76,9 @@ implementation
   {$i lclgtkeventer.inc}
 {$endif}
 
-{$ifdef LCLQT}
-  {$i lclgtkeventer.inc} // identical code ;)
+{$if Defined(LCLQT) or Defined(LCLQT5) or Defined(LCLQT6)}
+  // The gtkeventer works also for the QT widgetsets. No need to bring an own one.
+  {$i lclgtkeventer.inc}
 {$endif}
 
 end.


### PR DESCRIPTION
Looks like the gtk eventer also works for QT5 and 6, so this simple change makes lnet compatible with both. If you don't have any concerns, you might want to add this upstream :-)